### PR TITLE
Make auto-capture request off by default

### DIFF
--- a/packages/backend/src/stores/settings.ts
+++ b/packages/backend/src/stores/settings.ts
@@ -7,7 +7,7 @@ export class SettingsStore {
 
   private constructor() {
     this.settings = {
-      autoCaptureRequests: true,
+      autoCaptureRequests: false,
       autoRunAnalysis: false,
     };
   }

--- a/packages/frontend/src/index.dev.ts
+++ b/packages/frontend/src/index.dev.ts
@@ -231,7 +231,7 @@ const backend: API & Record<string, unknown> = {
   },
   getSettings: () => {
     return {
-      autoCaptureRequests: true,
+      autoCaptureRequests: false,
       autoRunAnalysis: false,
     };
   },


### PR DESCRIPTION
Fixes #6

Set `autoCaptureRequests` to `false` by default.

* **Backend Changes:**
  - Modify `packages/backend/src/stores/settings.ts` to set `autoCaptureRequests` to `false` by default in the constructor.

* **Frontend Changes:**
  - Modify `packages/frontend/src/index.dev.ts` to set `autoCaptureRequests` to `false` by default in the `getSettings` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/caido-community/authmatrix/issues/6?shareId=dfe95043-5414-48b1-8f72-774e9b1f8d30).